### PR TITLE
update readme. change default value for rotation-probability to 0.013333

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ cargo run --bin write-accounts -- --num-nodes <num-nodes> --account-file <path-t
 - Read accounts from the file you created in (Option 1) and simulate the network
     - Note it will simulate all of the accounts in the file. 
 ```
-cargo run --bin gossip-sim -- --account-file <path-to-yaml-file> --accounts-from-yaml --push-fanout <push_fanout> --active-set-size <active_set_size> --iterations <number_of_gossip_iterations> --origin-rank <origin_stake_rank>
+cargo run --bin gossip-sim -- --account-file <path-to-yaml-file> --accounts-from-yaml --push-fanout <push_fanout> --active-set-size <active_set_size> --iterations <number_of_gossip_iterations> --origin-rank <origin_stake_rank> -p <probability-of-active-set-rotation> --min-ingress-nodes <min-ingress-nodes> --stake-threshold <min-stake-threshol>
 ```
 #### Option 3: Pull accounts from mainnet and run simulation
 - This will pull all node accounts from mainnet and simulate the network.
 ```
-cargo run --bin gossip-sim -- --account-file `<path-to-yaml-file>` --accounts-from-yaml --push-fanout <push_fanout> --active-set-size <active_set_size> --iterations <number_of_gossip_iterations> --origin-rank <origin_stake_rank>
+cargo run --bin gossip-sim -- --account-file `<path-to-yaml-file>` --accounts-from-yaml --push-fanout <push_fanout> --active-set-size <active_set_size> --iterations <number_of_gossip_iterations> --origin-rank <origin_stake_rank> -p <probability-of-active-set-rotation> --min-ingress-nodes <min-ingress-nodes> --stake-threshold <min-stake-threshol>
 ```
 
 ## Interpreting the output
@@ -163,11 +163,7 @@ D -> C
 
 
 ## Caveat
-- Currently just takes the first node in the account list and uses it as the origin! Can't specify origin yet.
-- Only simulates a single round of gossip. aka active_sets are rotated once at the beginning and the simulation runs for that state
-- We do not simulate pruning (WIP)
 - We do not simulate pull requests
-- MST is the true definition of an MST. BUT, in solana we want to maintain at least two incoming connections.
 
 ## Progress
 - [x] Initialize all node with respective stakes and simulated active_sets
@@ -180,9 +176,9 @@ D -> C
 - [x] Identify MST src->vec<dest>
 - [x] Identify dest->vec<src> prunes
 - [x] write tests for above
-- [ ] implement pruning logic.
-- [ ] measure coverage for different `CRDS_GOSSIP_PUSH_FANOUT` and `CRDS_GOSSIP_PUSH_ACTIVE_SET_SIZE`
-- [ ] maintain minimum stake threshold and minimum incoming connections when pruning
+- [x] implement pruning logic.
+- [x] measure coverage for different `CRDS_GOSSIP_PUSH_FANOUT` and `CRDS_GOSSIP_PUSH_ACTIVE_SET_SIZE`
+- [x] maintain minimum stake threshold and minimum incoming connections when pruning
 
 
 

--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -95,7 +95,7 @@ fn parse_matches() -> ArgMatches {
                 .long("rotation-probability")
                 .short('p')
                 .takes_value(true)
-                .default_value(".01")
+                .default_value(".013333") // avg. one rotation for all nodes per 75 gossip rounds (1/75)
                 .validator(|s| match s.parse::<f64>() {
                     Ok(n) if n >= 0.0 && n <= 1.0 => Ok(()),
                     _ => Err(String::from("active_set_rotation_probability must be between 0 and 1")),

--- a/src/gossip_stats.rs
+++ b/src/gossip_stats.rs
@@ -107,7 +107,7 @@ impl HopsStat {
         info!("Hops {}", self.mean);
         info!("Hops {}", self.median);
         info!("Hops {}", self.max);
-        info!("Hops {}", self.min);
+        // info!("Hops {}", self.min); // min hops is always 0
     }
     
 }


### PR DESCRIPTION
change rotation-probability default to 0.0133333 = 1/75
Reason:
- Gossip loop runs once every 100ms
- active sets are rotated once every 7.5ms
- So we have 75 gossip iterations per active set state on each node
- On average, every 75 gossip iterations, all nodes should rotate their active set once. 
- for each node their should be a 1/75 chance that its active set will be rotated
- so default is 1/75 or 0.013333