### PR TITLE
add iterative testing w/ configurable parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,39 @@ cargo run --bin gossip-sim --
     --num-buckets <num-buckets-for-histogram>
 ```
 
+#### Option 4: Pull accounts, run multiple simulations, change specific config param
+- This will pull all node accounts from mainnet and simulate the network.
+```
+cargo run --bin gossip-sim --
+    --push-fanout <push_fanout> 
+    --active-set-size <active_set_size> 
+    --iterations <number_of_gossip_iterations> 
+    --origin-rank <origin_stake_rank> 
+    --rotation-probability <probability-of-active-set-rotation> 
+    --min-ingress-nodes <min-ingress-nodes> 
+    --stake-threshold <min-stake-threshold>
+    --filter-zero-staked-nodes
+    --num-buckets <num-buckets-for-histogram>
+    --test-type <test-type>
+    --num-simulations <num-simulations>
+    --step-size <step-size>
+```
+`test-type` is an Enum that can be set to one of the following:
+```
+active-set-size
+push-fanout
+min-ingress-nodes
+min-stake-threshold
+origin-rank
+[default: no-test]
+```
+So if `test-type` is set to `active-set-size`, the first simulation will run gossip with an `active-set-size` of `--active-set-size <active_set_size>` passed in. 
+On each simulation run, the `active-set-size` will increment by `step-size`. 
+The number of times a simulation is run (and `active-set-size` incremented) is defined by `num-simulations`.
+Default if `test-type` is not set is `no-test`. Meaning everything will run just once as before (so would be same as Option 2 or Option 3 above)
+
+
+
 ## Interpreting the output
 Prints out coverage, RMR, Aggregate Hop info, LDH, stranded nodes
 - Coverage:

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -26,12 +26,25 @@ pub(crate) const CRDS_UNIQUE_PUBKEY_CAPACITY: usize = 8192;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Testing {
-    ActiveSetSize(bool),
-    PushFanout(bool),
-    MinIngressNodes(bool),
-    MinStakeThreshold(bool),
-    OriginRank(bool),
-    NoTest(bool),
+    ActiveSetSize,
+    PushFanout,
+    MinIngressNodes,
+    MinStakeThreshold,
+    OriginRank,
+    NoTest,
+}
+
+impl std::fmt::Display for Testing {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Testing::ActiveSetSize => write!(f, "ActiveSetSize"),
+            Testing::PushFanout => write!(f, "PushFanout()"),
+            Testing::MinIngressNodes => write!(f, "MinIngressNodes()"),
+            Testing::MinStakeThreshold => write!(f, "MinStakeThreshold()"),
+            Testing::OriginRank => write!(f, "OriginRank()"),
+            Testing::NoTest => write!(f, "NoTest()"),
+        }
+    }
 }
 
 impl FromStr for Testing {
@@ -39,12 +52,12 @@ impl FromStr for Testing {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "active-set-size" => Ok(Testing::ActiveSetSize(true)),
-            "push-fanout" => Ok(Testing::PushFanout(true)),
-            "min-ingress-nodes" => Ok(Testing::MinIngressNodes(true)),
-            "min-stake-threshold" => Ok(Testing::MinStakeThreshold(true)),
-            "origin-rank" => Ok(Testing::OriginRank(true)),
-            "no-test" => Ok(Testing::NoTest(true)),
+            "active-set-size" => Ok(Testing::ActiveSetSize),
+            "push-fanout" => Ok(Testing::PushFanout),
+            "min-ingress-nodes" => Ok(Testing::MinIngressNodes),
+            "min-stake-threshold" => Ok(Testing::MinStakeThreshold),
+            "origin-rank" => Ok(Testing::OriginRank),
+            "no-test" => Ok(Testing::NoTest),
             _ => Err(format!("Invalid test type: {}", s)),
         }
     }

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -24,6 +24,56 @@ use {
 #[cfg_attr(test, cfg(test))]
 pub(crate) const CRDS_UNIQUE_PUBKEY_CAPACITY: usize = 8192;
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Testing {
+    ActiveSetSize(bool),
+    PushFanout(bool),
+    MinIngressNodes(bool),
+    MinStakeThreshold(bool),
+    OriginRank(bool),
+    NoTest(bool),
+}
+
+impl FromStr for Testing {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active-set-size" => Ok(Testing::ActiveSetSize(true)),
+            "push-fanout" => Ok(Testing::PushFanout(true)),
+            "min-ingress-nodes" => Ok(Testing::MinIngressNodes(true)),
+            "min-stake-threshold" => Ok(Testing::MinStakeThreshold(true)),
+            "origin-rank" => Ok(Testing::OriginRank(true)),
+            "no-test" => Ok(Testing::NoTest(true)),
+            _ => Err(format!("Invalid test type: {}", s)),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum StepSize {
+    Integer(usize),
+    Float(f64),
+}
+
+impl From<StepSize> for usize {
+    fn from(value: StepSize) -> Self {
+        match value {
+            StepSize::Integer(num) => num,
+            StepSize::Float(num) => num as usize,
+        }
+    }
+}
+
+impl From<StepSize> for f64 {
+    fn from(value: StepSize) -> Self {
+        match value {
+            StepSize::Integer(num) => num as f64,
+            StepSize::Float(num) => num,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct Config<'a> {
     pub gossip_push_fanout: usize,
@@ -37,6 +87,9 @@ pub struct Config<'a> {
     pub min_ingress_nodes: usize,
     pub filter_zero_staked_nodes: bool,
     pub num_buckets_for_stranded_node_hist: u64,
+    pub test_type: Testing,
+    pub num_simulations: usize,
+    pub step_size: StepSize,
 }
 
 pub struct Cluster {
@@ -578,7 +631,6 @@ impl Cluster {
 
 
 }
-
 
 pub struct Node {
     _clock: Instant,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub enum RouterError {
     SendError,
 }
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Clone, Copy, Error, PartialEq)]
 pub enum HopsStats {
     Mean(f64),
     Median(f64),
@@ -45,7 +45,7 @@ pub enum HopsStats {
     Min(u64),
 }
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Clone, Copy, Error, PartialEq)]
 pub enum Stats {
     Mean(f64),
     Median(f64),


### PR DESCRIPTION
Add in three command line flags:
```
    --test-type <test-type>
    --num-simulations <num-simulations>
    --step-size <step-size>
```
This let's us sweep across multiple values for a configurable parameter in one overall test. 
Current support for `test-type` includes:
```
active-set-size
push-fanout
min-ingress-nodes
min-stake-threshold
origin-rank
[default: no-test]
```