### PR TITLE
increase number of tests to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,39 @@ cargo run --bin gossip-sim --
     --num-buckets <num-buckets-for-histogram>
 ```
 
+#### Option 4: Pull accounts, run multiple simulations, change specific config param
+- This will pull all node accounts from mainnet and simulate the network.
+```
+cargo run --bin gossip-sim --
+    --push-fanout <push_fanout> 
+    --active-set-size <active_set_size> 
+    --iterations <number_of_gossip_iterations> 
+    --origin-rank <origin_stake_rank> 
+    --rotation-probability <probability-of-active-set-rotation> 
+    --min-ingress-nodes <min-ingress-nodes> 
+    --stake-threshold <min-stake-threshold>
+    --filter-zero-staked-nodes
+    --num-buckets <num-buckets-for-histogram>
+    --test-type <test-type>
+    --num-simulations <num-simulations>
+    --step-size <step-size>
+```
+`test-type` is an Enum that can be set to one of the following:
+```
+active-set-size
+push-fanout
+min-ingress-nodes
+min-stake-threshold
+origin-rank
+[default: no-test]
+```
+So if `test-type` is set to `active-set-size`, the first simulation will run gossip with an `active-set-size` of `--active-set-size <active_set_size>` passed in. 
+On each simulation run, the `active-set-size` will increment by `step-size`. 
+The number of times a simulation is run (and `active-set-size` incremented) is defined by `num-simulations`.
+Default if `test-type` is not set is `no-test`. Meaning everything will run just once as before (so would be same as Option 2 or Option 3 above)
+
+
+
 ## Interpreting the output
 Prints out coverage, RMR, Aggregate Hop info, LDH, stranded nodes
 - Coverage:

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -26,12 +26,25 @@ pub(crate) const CRDS_UNIQUE_PUBKEY_CAPACITY: usize = 8192;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Testing {
-    ActiveSetSize(bool),
-    PushFanout(bool),
-    MinIngressNodes(bool),
-    MinStakeThreshold(bool),
-    OriginRank(bool),
-    NoTest(bool),
+    ActiveSetSize,
+    PushFanout,
+    MinIngressNodes,
+    MinStakeThreshold,
+    OriginRank,
+    NoTest,
+}
+
+impl std::fmt::Display for Testing {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Testing::ActiveSetSize => write!(f, "ActiveSetSize"),
+            Testing::PushFanout => write!(f, "PushFanout()"),
+            Testing::MinIngressNodes => write!(f, "MinIngressNodes()"),
+            Testing::MinStakeThreshold => write!(f, "MinStakeThreshold()"),
+            Testing::OriginRank => write!(f, "OriginRank()"),
+            Testing::NoTest => write!(f, "NoTest()"),
+        }
+    }
 }
 
 impl FromStr for Testing {
@@ -39,12 +52,12 @@ impl FromStr for Testing {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "active-set-size" => Ok(Testing::ActiveSetSize(true)),
-            "push-fanout" => Ok(Testing::PushFanout(true)),
-            "min-ingress-nodes" => Ok(Testing::MinIngressNodes(true)),
-            "min-stake-threshold" => Ok(Testing::MinStakeThreshold(true)),
-            "origin-rank" => Ok(Testing::OriginRank(true)),
-            "no-test" => Ok(Testing::NoTest(true)),
+            "active-set-size" => Ok(Testing::ActiveSetSize),
+            "push-fanout" => Ok(Testing::PushFanout),
+            "min-ingress-nodes" => Ok(Testing::MinIngressNodes),
+            "min-stake-threshold" => Ok(Testing::MinStakeThreshold),
+            "origin-rank" => Ok(Testing::OriginRank),
+            "no-test" => Ok(Testing::NoTest),
             _ => Err(format!("Invalid test type: {}", s)),
         }
     }

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -24,6 +24,56 @@ use {
 #[cfg_attr(test, cfg(test))]
 pub(crate) const CRDS_UNIQUE_PUBKEY_CAPACITY: usize = 8192;
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Testing {
+    ActiveSetSize(bool),
+    PushFanout(bool),
+    MinIngressNodes(bool),
+    MinStakeThreshold(bool),
+    OriginRank(bool),
+    NoTest(bool),
+}
+
+impl FromStr for Testing {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active-set-size" => Ok(Testing::ActiveSetSize(true)),
+            "push-fanout" => Ok(Testing::PushFanout(true)),
+            "min-ingress-nodes" => Ok(Testing::MinIngressNodes(true)),
+            "min-stake-threshold" => Ok(Testing::MinStakeThreshold(true)),
+            "origin-rank" => Ok(Testing::OriginRank(true)),
+            "no-test" => Ok(Testing::NoTest(true)),
+            _ => Err(format!("Invalid test type: {}", s)),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum StepSize {
+    Integer(usize),
+    Float(f64),
+}
+
+impl From<StepSize> for usize {
+    fn from(value: StepSize) -> Self {
+        match value {
+            StepSize::Integer(num) => num,
+            StepSize::Float(num) => num as usize,
+        }
+    }
+}
+
+impl From<StepSize> for f64 {
+    fn from(value: StepSize) -> Self {
+        match value {
+            StepSize::Integer(num) => num as f64,
+            StepSize::Float(num) => num,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct Config<'a> {
     pub gossip_push_fanout: usize,
@@ -37,6 +87,9 @@ pub struct Config<'a> {
     pub min_ingress_nodes: usize,
     pub filter_zero_staked_nodes: bool,
     pub num_buckets_for_stranded_node_hist: u64,
+    pub test_type: Testing,
+    pub num_simulations: usize,
+    pub step_size: StepSize,
 }
 
 pub struct Cluster {
@@ -578,7 +631,6 @@ impl Cluster {
 
 
 }
-
 
 pub struct Node {
     _clock: Instant,

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -236,7 +236,7 @@ impl Cluster {
             .len()
     }
 
-    pub fn get_orders(
+    pub fn get_orders_hops(
         &self,
         dest_node: &Pubkey,
         src_node: &Pubkey,
@@ -245,6 +245,12 @@ impl Cluster {
             .get(dest_node)
             .unwrap()
             .get(src_node)
+    }
+
+    pub fn get_orders(
+        &self,
+    ) -> &HashMap<Pubkey, HashMap<Pubkey, u64>> {
+        &self.orders
     }
 
     pub fn get_visited_len(
@@ -342,6 +348,12 @@ impl Cluster {
                 info!("Prunee: {:?}", prunee);
             }
         }
+    }
+
+    pub fn get_pushes(
+        &self,
+    ) -> &HashMap<Pubkey, HashSet<Pubkey>> {
+        &self.pushes
     }
 
     pub fn print_pushes(
@@ -455,6 +467,9 @@ impl Cluster {
                     // }
 
                     // add neighbor to current_node pushes map
+                    // I think this is the one we care about at all times.
+                    // TBH not sure MST is really useful. 
+                    // We care about who a node is pushing too.
                     self.pushes
                         .get_mut(&current_node_pubkey)
                         .unwrap()
@@ -965,25 +980,25 @@ mod tests {
         
         // check num of hops per inbound connection
         // M
-        assert_eq!(cluster.get_orders(&nodes[0].pubkey(), &nodes[1].pubkey()).unwrap(), &4u64); // M <- h, 4 hops
-        assert_eq!(cluster.get_orders(&nodes[0].pubkey(), &nodes[4].pubkey()).unwrap(), &2u64); // M <- j, 2 hops
+        assert_eq!(cluster.get_orders_hops(&nodes[0].pubkey(), &nodes[1].pubkey()).unwrap(), &4u64); // M <- h, 4 hops
+        assert_eq!(cluster.get_orders_hops(&nodes[0].pubkey(), &nodes[4].pubkey()).unwrap(), &2u64); // M <- j, 2 hops
 
         // h
-        assert_eq!(cluster.get_orders(&nodes[1].pubkey(), &nodes[0].pubkey()).unwrap(), &3u64); // h <- M, 3 hops
+        assert_eq!(cluster.get_orders_hops(&nodes[1].pubkey(), &nodes[0].pubkey()).unwrap(), &3u64); // h <- M, 3 hops
 
         // 3 
-        assert_eq!(cluster.get_orders(&nodes[2].pubkey(), &nodes[0].pubkey()).unwrap(), &3u64); // 3 <- M, 3 hops
-        assert_eq!(cluster.get_orders(&nodes[2].pubkey(), &nodes[3].pubkey()).unwrap(), &3u64); // 3 <- P, 3 hops
-        assert_eq!(cluster.get_orders(&nodes[2].pubkey(), &nodes[5].pubkey()).unwrap(), &1u64); // 3 <- 5, 1 hop
+        assert_eq!(cluster.get_orders_hops(&nodes[2].pubkey(), &nodes[0].pubkey()).unwrap(), &3u64); // 3 <- M, 3 hops
+        assert_eq!(cluster.get_orders_hops(&nodes[2].pubkey(), &nodes[3].pubkey()).unwrap(), &3u64); // 3 <- P, 3 hops
+        assert_eq!(cluster.get_orders_hops(&nodes[2].pubkey(), &nodes[5].pubkey()).unwrap(), &1u64); // 3 <- 5, 1 hop
 
         // P
-        assert_eq!(cluster.get_orders(&nodes[0].pubkey(), &nodes[1].pubkey()).unwrap(), &4u64); // M <- h, 4 hops
-        assert_eq!(cluster.get_orders(&nodes[0].pubkey(), &nodes[4].pubkey()).unwrap(), &2u64); // M <- j, 2 hops
+        assert_eq!(cluster.get_orders_hops(&nodes[0].pubkey(), &nodes[1].pubkey()).unwrap(), &4u64); // M <- h, 4 hops
+        assert_eq!(cluster.get_orders_hops(&nodes[0].pubkey(), &nodes[4].pubkey()).unwrap(), &2u64); // M <- j, 2 hops
 
         // j
-        assert_eq!(cluster.get_orders(&nodes[4].pubkey(), &nodes[2].pubkey()).unwrap(), &2u64); // j <- 3, 2 hops
-        assert_eq!(cluster.get_orders(&nodes[4].pubkey(), &nodes[3].pubkey()).unwrap(), &3u64); // j <- P, 3 hops
-        assert_eq!(cluster.get_orders(&nodes[4].pubkey(), &nodes[5].pubkey()).unwrap(), &1u64); // j <- 5, 1 hop
+        assert_eq!(cluster.get_orders_hops(&nodes[4].pubkey(), &nodes[2].pubkey()).unwrap(), &2u64); // j <- 3, 2 hops
+        assert_eq!(cluster.get_orders_hops(&nodes[4].pubkey(), &nodes[3].pubkey()).unwrap(), &3u64); // j <- P, 3 hops
+        assert_eq!(cluster.get_orders_hops(&nodes[4].pubkey(), &nodes[5].pubkey()).unwrap(), &1u64); // j <- 5, 1 hop
 
         // 5 - None
         // ensure origin is NOT in the orders map

--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -328,6 +328,9 @@ fn run_simulation(config: &Config, matches: &ArgMatches, gossip_stats_collection
             Err(_) => error!("Network RMR error. # of nodes is 1."),
         }
 
+        stats.calculate_outbound_branching_factor(cluster.get_pushes());
+        stats.calculate_inbound_branching_factor(cluster.get_orders());
+
         cluster.consume_messages(origin_pubkey, &mut nodes);
         cluster.send_prunes(*origin_pubkey, &mut nodes, config.prune_stake_threshold, config.min_ingress_nodes, &stakes);
         

--- a/src/gossip_stats.rs
+++ b/src/gossip_stats.rs
@@ -189,32 +189,47 @@ impl HopsStatCollection {
 }
 
 #[derive(Debug, Clone)]
-pub struct CoverageStatsCollection {
-    coverages: Vec<f64>,
+pub struct StatCollection {
+    collection: Vec<f64>,
     mean: Stats,
     median: Stats,
     max: Stats,
     min: Stats,
+    collection_type: String,
 }
 
-impl Default for CoverageStatsCollection {
+impl Default for StatCollection {
     fn default() -> Self {
         Self {
-            coverages: Vec::default(),
+            collection: Vec::default(),
             mean: Stats::Mean(0.0),
             median: Stats::Median(0.0),
             max: Stats::Max(0.0),
             min: Stats::Min(0.0),
+            collection_type: String::new(),
         }
     }
 }
 
-impl CoverageStatsCollection {
+impl StatCollection {
+    pub fn new(
+        collection_type: &str,
+    ) -> Self {
+        StatCollection {
+            collection: Vec::default(),
+            mean: Stats::Mean(0.0),
+            median: Stats::Median(0.0),
+            max: Stats::Max(0.0),
+            min: Stats::Min(0.0),
+            collection_type: String::from(collection_type),
+        }
+    }
+
     pub fn calculate_stats (
         &mut self,
     ) {
         // clone to maintain iteration order for print_stats
-        let mut sorted_coverages = self.coverages.clone();
+        let mut sorted_coverages = self.collection.clone();
         sorted_coverages
             .sort_by(|a, b| a
                     .partial_cmp(b)
@@ -269,14 +284,21 @@ impl CoverageStatsCollection {
         }
     }
 
+    pub fn get_stat_by_index(
+        &self,
+        index: usize,
+    ) -> &f64 {
+        &self.collection[index]
+    }
+
     pub fn print_stats (
         &self,
     ) {
         // info!("Number of iterations: {}", self.coverages.len());
-        info!("Coverage {}", self.mean);
-        info!("Coverage {}", self.median);
-        info!("Coverage {}", self.max);
-        info!("Coverage {}", self.min);
+        info!("{} {}", self.collection_type, self.mean);
+        info!("{} {}", self.collection_type, self.median);
+        info!("{} {}", self.collection_type, self.max);
+        info!("{} {}", self.collection_type, self.min);
     }    
 }
 
@@ -343,105 +365,6 @@ impl RelativeMessageRedundancy {
 impl std::fmt::Display for RelativeMessageRedundancy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "m: {}, n: {}, rmr: {:.6}", self.m, self.n, self.rmr)
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct RelativeMessageRedundancyCollection {
-    rmrs: Vec<f64>,
-    mean: Stats,
-    median: Stats,
-    max: Stats,
-    min: Stats,
-}
-
-impl Default for RelativeMessageRedundancyCollection {
-    fn default() -> Self {
-        Self {
-            rmrs: Vec::default(),
-            mean: Stats::Mean(0.0),
-            median: Stats::Median(0.0),
-            max: Stats::Max(0.0),
-            min: Stats::Min(0.0),
-        }
-    }
-}
-
-impl RelativeMessageRedundancyCollection {
-    pub fn calculate_stats (
-        &mut self,
-    ) {
-        // clone to maintain iteration order for print_stats
-        let mut sorted_rms = self.rmrs.clone();
-        sorted_rms
-            .sort_by(|a, b| a
-                    .partial_cmp(b)
-                    .unwrap());
-        let len = sorted_rms.len();
-        let mean = sorted_rms
-            .iter()
-            .sum::<f64>() / len as f64;
-        let median = if len % 2 == 0 {
-            (sorted_rms[len / 2 - 1] + sorted_rms[len / 2]) / 2.0
-        } else {
-            sorted_rms[len / 2]
-        };
-        let max = *sorted_rms
-            .last()
-            .unwrap_or(&0.0);
-        let min = *sorted_rms
-            .first()
-            .unwrap_or(&0.0);
-
-        self.mean = Stats::Mean(mean);
-        self.median = Stats::Median(median);
-        self.max = Stats::Max(max);
-        self.min = Stats::Min(min);
-    }
-
-    pub fn get_rmr_by_index(
-        &self,
-        index: usize,
-    ) -> &f64 {
-        &self.rmrs[index]
-    }
-
-    pub fn mean(&self) -> f64 {
-        match &self.mean {
-            Stats::Mean(val) => *val,
-            _ => panic!("Unexpected value in mean field"),
-        }
-    }
-
-    pub fn max(&self) -> f64 {
-        match &self.max {
-            Stats::Max(val) => *val,
-            _ => panic!("Unexpected value in max field"),
-        }
-    }
-
-    pub fn min(&self) -> f64 {
-        match &self.min {
-            Stats::Min(val) => *val,
-            _ => panic!("Unexpected value in min field"),
-        }
-    }
-
-    pub fn median(&self) -> f64 {
-        match &self.median {
-            Stats::Median(val) => *val,
-            _ => panic!("Unexpected value in median field"),
-        }
-    }
-
-    pub fn print_stats (
-        &self,
-    ) {
-        // info!("Number of iterations: {}", self.rmrs.len());
-        info!("RMR {}", self.mean);
-        info!("RMR {}", self.median);
-        info!("RMR {}", self.max);
-        info!("RMR {}", self.min);
     }
 }
 
@@ -805,17 +728,7 @@ impl StrandedNodeCollection {
 }
 
 #[derive(Debug, Clone)]
-pub struct BranchingFactor {
-    // factor: f64,
-}
-
-// impl Default for BranchingFactor {
-//     fn default() -> Self {
-//         Self {
-//             factor: 0.0,
-//         }
-//     }
-// }
+pub struct BranchingFactor { }
 
 // NOTE: This will measure branching factor of all visited nodes
 // Does NOT include nodes that were not visited
@@ -860,107 +773,6 @@ impl BranchingFactor {
 }
 
 #[derive(Debug, Clone)]
-pub struct BranchingFactorCollection {
-    factors: Vec<f64>,
-    mean: Stats,
-    median: Stats,
-    max: Stats,
-    min: Stats,
-}
-
-impl Default for BranchingFactorCollection {
-    fn default() -> Self {
-        Self {
-            factors: Vec::default(),
-            mean: Stats::Mean(0.0),
-            median: Stats::Median(0.0),
-            max: Stats::Max(0.0),
-            min: Stats::Min(0.0),
-        }
-    }
-}
-
-impl BranchingFactorCollection {
-    pub fn push(
-        &mut self,
-        factor: f64,
-    ) {
-        self.factors.push(factor);
-    }
-
-    pub fn calculate_stats (
-        &mut self,
-    ) {
-        // clone to maintain iteration order for print_stats
-        let mut sorted_factors = self.factors.clone();
-        sorted_factors
-            .sort_by(|a, b| a
-                    .partial_cmp(b)
-                    .unwrap());
-        let len = sorted_factors.len();
-        let mean = sorted_factors
-            .iter()
-            .sum::<f64>() / len as f64;
-        let median = if len % 2 == 0 {
-            (sorted_factors[len / 2 - 1] + sorted_factors[len / 2]) / 2.0
-        } else {
-            sorted_factors[len / 2]
-        };
-        let max = *sorted_factors
-            .last()
-            .unwrap_or(&0.0);
-        let min = *sorted_factors
-            .first()
-            .unwrap_or(&0.0);
-
-        self.mean = Stats::Mean(mean);
-        self.median = Stats::Median(median);
-        self.max = Stats::Max(max);
-        self.min = Stats::Min(min);
-    }
-
-    pub fn mean(&self) -> f64 {
-        match &self.mean {
-            Stats::Mean(val) => *val,
-            _ => panic!("Unexpected value in mean field"),
-        }
-    }
-
-    pub fn max(&self) -> f64 {
-        match &self.max {
-            Stats::Max(val) => *val,
-            _ => panic!("Unexpected value in max field"),
-        }
-    }
-
-    pub fn min(&self) -> f64 {
-        match &self.min {
-            Stats::Min(val) => *val,
-            _ => panic!("Unexpected value in min field"),
-        }
-    }
-
-    pub fn median(&self) -> f64 {
-        match &self.median {
-            Stats::Median(val) => *val,
-            _ => panic!("Unexpected value in median field"),
-        }
-    }
-
-    pub fn print_stats (
-        &self,
-        direction: &str,
-    ) {
-        // info!("Number of iterations: {}", self.coverages.len());
-        info!("{} Branching Factor: {}", direction, self.mean);
-        info!("{} Branching Factor: {}", direction, self.median);
-        info!("{} Branching Factor: {}", direction, self.max);
-        info!("{} Branching Factor: {}", direction, self.min);
-    }   
-}
-
-
-#[derive(Debug, Clone)]
 pub struct SimulationParamaters {
     pub gossip_push_fanout: usize,
     pub gossip_active_set_size: usize,
@@ -994,11 +806,11 @@ impl Default for SimulationParamaters {
 #[derive(Debug, Clone)]
 pub struct GossipStats {
     hops_stats: HopsStatCollection,
-    coverage_stats: CoverageStatsCollection,
-    relative_message_redundancy_stats: RelativeMessageRedundancyCollection,
+    coverage_stats: StatCollection,
+    relative_message_redundancy_stats: StatCollection,
     stranded_nodes: StrandedNodeCollection,
-    outbound_branching_factors: BranchingFactorCollection,
-    inbound_branching_factors: BranchingFactorCollection,
+    outbound_branching_factors: StatCollection,
+    inbound_branching_factors: StatCollection,
     origin: Pubkey,
     pub simulation_parameters: SimulationParamaters,
 }
@@ -1007,11 +819,11 @@ impl Default for GossipStats {
     fn default() -> Self {
         GossipStats { 
             hops_stats: HopsStatCollection::default(), 
-            coverage_stats: CoverageStatsCollection::default(),
-            relative_message_redundancy_stats: RelativeMessageRedundancyCollection::default(),
+            coverage_stats: StatCollection::new("Coverage"),
+            relative_message_redundancy_stats: StatCollection::new("RMR"),
             stranded_nodes: StrandedNodeCollection::default(),
-            outbound_branching_factors: BranchingFactorCollection::default(),
-            inbound_branching_factors: BranchingFactorCollection::default(),
+            outbound_branching_factors: StatCollection::new("Outbound Branching Factor"),
+            inbound_branching_factors: StatCollection::new("Inbound Branching Factor"),
             origin: Pubkey::default(),
             simulation_parameters: SimulationParamaters::default(),
         }
@@ -1131,10 +943,10 @@ impl GossipStats {
         info!("|------ LAST DELIVERY HOP STATS ------|");
         info!("|-------------------------------------|");     
         let stats = self.hops_stats.get_last_delivery_hop_stats();
-        info!("LDH Mean: {}", stats.mean);
-        info!("LDH Median: {}", stats.median);
-        info!("LDH Max: {}", stats.max);
-        info!("LDH Min: {}", stats.min);
+        info!("LDH {}", stats.mean);
+        info!("LDH {}", stats.median);
+        info!("LDH {}", stats.max);
+        info!("LDH {}", stats.min);
     }
 
     pub fn get_last_delivery_hop_stats(
@@ -1154,7 +966,7 @@ impl GossipStats {
         &mut self,
         value: f64,
     ) {
-        self.coverage_stats.coverages.push(value);
+        self.coverage_stats.collection.push(value);
     }
 
     pub fn calculate_coverage_stats(
@@ -1187,7 +999,7 @@ impl GossipStats {
         &mut self,
         rmr: f64,
     ) {
-        self.relative_message_redundancy_stats.rmrs.push(rmr);
+        self.relative_message_redundancy_stats.collection.push(rmr);
     }
 
     pub fn calculate_rmr_stats(
@@ -1200,7 +1012,7 @@ impl GossipStats {
         &self,
         index: usize,
     ) -> &f64 {
-        self.relative_message_redundancy_stats.get_rmr_by_index(index)
+        self.relative_message_redundancy_stats.get_stat_by_index(index)
     }
 
     pub fn get_rmr_stats(
@@ -1343,11 +1155,11 @@ impl GossipStats {
         info!("|-----------------------------------|");
         info!("|---- OUTBOUND BRANCHING FACTOR ----|");
         info!("|-----------------------------------|"); 
-        self.outbound_branching_factors.print_stats("Outbound");
+        self.outbound_branching_factors.print_stats();
         info!("|----------------------------------|");
         info!("|---- INBOUND BRANCHING FACTOR ----|");
         info!("|----------------------------------|"); 
-        self.inbound_branching_factors.print_stats("Inbound");
+        self.inbound_branching_factors.print_stats();
     }
 
     pub fn calculate_outbound_branching_factor(
@@ -1355,6 +1167,7 @@ impl GossipStats {
         pushes: &HashMap<Pubkey, HashSet<Pubkey>>,
     ) {
         self.outbound_branching_factors
+            .collection
             .push(
                 BranchingFactor::calculate_outbound(pushes));
 
@@ -1365,6 +1178,7 @@ impl GossipStats {
         orders: &HashMap<Pubkey, HashMap<Pubkey, u64>>,
     ) {
         self.inbound_branching_factors
+        .collection
             .push(
                 BranchingFactor::calculate_inbound(orders));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,3 +82,12 @@ pub fn get_json_rpc_url(json_rpc_url: &str) -> &str {
         _ => json_rpc_url,
     }
 }
+
+// trait Statistics<T> {
+//     fn calculate_stats(
+//         &mut self,
+//         stats: &[T],
+//     ) {
+
+//     }
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,12 +82,3 @@ pub fn get_json_rpc_url(json_rpc_url: &str) -> &str {
         _ => json_rpc_url,
     }
 }
-
-// trait Statistics<T> {
-//     fn calculate_stats(
-//         &mut self,
-//         stats: &[T],
-//     ) {
-
-//     }
-// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub enum RouterError {
     SendError,
 }
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Clone, Copy, Error, PartialEq)]
 pub enum HopsStats {
     Mean(f64),
     Median(f64),
@@ -45,7 +45,7 @@ pub enum HopsStats {
     Min(u64),
 }
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Clone, Copy, Error, PartialEq)]
 pub enum Stats {
     Mean(f64),
     Median(f64),


### PR DESCRIPTION
Add in additional flags for running multiple tests in series. 
Sweep across various configuration values. 
Also, refactor gossip-stats to improve code reuse. 
```
cargo run --bin gossip-sim --
    --push-fanout <push_fanout> 
    --active-set-size <active_set_size> 
    --iterations <number_of_gossip_iterations> 
    --origin-rank <origin_stake_rank> 
    --rotation-probability <probability-of-active-set-rotation> 
    --min-ingress-nodes <min-ingress-nodes> 
    --stake-threshold <min-stake-threshold>
    --filter-zero-staked-nodes
    --num-buckets <num-buckets-for-histogram>
    --test-type <test-type>
    --num-simulations <num-simulations>
    --step-size <step-size>
```
`test-type` is an Enum that can be set to one of the following:
```
active-set-size
push-fanout
min-ingress-nodes
min-stake-threshold
origin-rank
[default: no-test]
```
So if `test-type` is set to `active-set-size`, the first simulation will run gossip with an `active-set-size` of `--active-set-size <active_set_size>` passed in. 
On each simulation run, the `active-set-size` will increment by `step-size`. 
The number of times a simulation is run (and `active-set-size` incremented) is defined by `num-simulations`.
Default if `test-type` is not set is `no-test`. Meaning everything will run just once as before (so would be same as Option 2 or Option 3 above)