### PR TITLE
add in warm up rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cargo run --bin gossip-sim --
     --num-buckets <num-buckets-for-histogram>
     --warm-up-rounds <warm_up_rounds>
 ```
-Note: `warm-up-rounds` sets the number of gossip iterations to run before collecting gossip statistics [default: 300]. It allows gossip to reach a sort of steady state. Without this, Gossip Statistics will include transient stats measued during the initial creation of the MST.
+Note: `warm-up-rounds` sets the number of gossip iterations to run before collecting gossip statistics [default: 200]. It allows gossip to reach a sort of steady state. Without this, Gossip Statistics will include transient stats measued during the initial creation of the MST.
 
 #### Option 3: Pull accounts from mainnet and run simulation
 - This will pull all node accounts from mainnet and simulate the network.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ cargo run --bin gossip-sim --
     --stake-threshold <min-stake-threshold>
     --filter-zero-staked-nodes
     --num-buckets <num-buckets-for-histogram>
+    --warm-up-rounds <warm_up_rounds>
 ```
+Note: `warm-up-rounds` sets the number of gossip iterations to run before collecting gossip statistics [default: 300]. It allows gossip to reach a sort of steady state. Without this, Gossip Statistics will include transient stats measued during the initial creation of the MST.
+
 #### Option 3: Pull accounts from mainnet and run simulation
 - This will pull all node accounts from mainnet and simulate the network.
 ```
@@ -87,6 +90,7 @@ cargo run --bin gossip-sim --
     --stake-threshold <min-stake-threshold>
     --filter-zero-staked-nodes
     --num-buckets <num-buckets-for-histogram>
+    --warm-up-rounds <warm_up_rounds>
 ```
 
 #### Option 4: Pull accounts, run multiple simulations, change specific config param
@@ -105,6 +109,7 @@ cargo run --bin gossip-sim --
     --test-type <test-type>
     --num-simulations <num-simulations>
     --step-size <step-size>
+    --warm-up-rounds <warm_up_rounds>
 ```
 `test-type` is an Enum that can be set to one of the following:
 ```
@@ -136,10 +141,9 @@ cargo run --bin gossip-sim --
     --fail-nodes
     --when-to-fail <gossip-iteration-to-fail-nodes-on>
     --fraction-to-fail <fraction-of-nodes-to-fail (0 < f < 1)>
+    --warm-up-rounds <warm_up_rounds>
 ```
 `fraction-to-fail` * total-nodes will fail right before the `when-to-fail`-th gossip iteration is run
-
-
 
 ## Interpreting the output
 Prints out coverage, RMR, Aggregate Hop info, LDH, stranded nodes

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -634,18 +634,14 @@ impl Cluster {
             self.prunes
                 .insert(node.pubkey(), prunes);
         }
-
     }
 
     // pruner has sent prunes to a bunch of nodes. we are going to handle
     // those prunes from the side of the nodes (aka the prunees)
     pub fn prune_connections(
         &mut self,
-        // origin: &Pubkey,
         node_map: &HashMap<Pubkey, &Node>,
-        // nodes: &mut Vec<Node>,
         stakes: &HashMap<Pubkey, u64>,
-        gossip_iteration: usize,
     ) {
         // pruner: sending the prunes.
         // prunes: peers and origins. 
@@ -654,7 +650,6 @@ impl Cluster {
             // from the pruner.
             if prunes.len() > 0 {
                 self.total_prunes += prunes.len();
-                // info!("iter: {}, pruner: {:?}, prune count: {}", gossip_iteration, pruner, prunes.len());
             }
             for (current_pubkey, origins) in prunes {
                 // now we switch into the context of the prunee. 
@@ -669,8 +664,7 @@ impl Cluster {
                 }
             }
         }
-        trace!("Iter: {}, total prunes: {}", gossip_iteration, self.total_prunes);
-
+        trace!("total prunes: {}", self.total_prunes);
     }
 
     pub fn chance_to_rotate<R: Rng>(
@@ -706,7 +700,6 @@ impl Cluster {
             nodes[i].fail_node();
             self.failed_nodes.insert(nodes[i].pubkey());
         }
-
         info!("Total nodes failed: {}", total_nodes_to_fail);
     }
 }

--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -333,7 +333,7 @@ fn run_simulation(config: &Config, matches: &ArgMatches, gossip_stats_collection
                 .iter()
                 .map(|node| (node.pubkey(), node))
                 .collect();
-            cluster.prune_connections(&node_map, &stakes, i);
+            cluster.prune_connections(&node_map, &stakes);
         }
 
         let mut rng = rand::thread_rng();

--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -189,7 +189,14 @@ fn parse_matches() -> ArgMatches {
                 .takes_value(true)
                 .default_value("0")
                 .requires("fail_nodes")
-                .help("Fail `fraction-to-fail` of total nodes in cluster"),
+                .help("On what iteration should the nodes fail"),
+        )
+        .arg(
+            Arg::with_name("warm_up_rounds")
+                .long("warm-up-rounds")
+                .takes_value(true)
+                .default_value("200")
+                .help("Number of gossip rounds to run before measuring statistics"),
         )
         .get_matches()
 }
@@ -317,50 +324,6 @@ fn run_simulation(config: &Config, matches: &ArgMatches, gossip_stats_collection
                 .collect();
             cluster.run_gossip(origin_pubkey, &stakes, &node_map);
         }
-        
-        // info!("Calculation Complete. Printing results...");
-        // cluster.print_hops();
-        // cluster.print_node_orders();
-
-        // info!("Origin Node: {:?}", origin_pubkey);
-        // cluster.print_mst();
-        // cluster.print_prunes();
-
-        let (coverage, stranded_nodes) = cluster.coverage(&stakes);
-        debug!("For origin {:?}, the cluster coverage is: {:.6}", origin_pubkey, coverage);
-        debug!("{} nodes are stranded", stranded_nodes);
-        if coverage < poor_coverage_threshold {
-            warn!("WARNING: poor coverage for origin: {:?}, {}", origin_pubkey, coverage);
-            _number_of_poor_coverage_runs += 1;
-        }
-
-        stats.insert_stranded_nodes(
-            &cluster.stranded_nodes(), 
-            &stakes
-        );
-        
-        stats.insert_coverage(coverage);
-        // stats.insert_hops_stat(
-        //     HopsStat::new(
-        //         cluster.get_distances()
-        //     )
-        // );
-
-        stats.insert_hops_stat(cluster.get_distances());
-
-        if log::log_enabled!(Level::Debug) {
-            cluster.print_pushes();
-        }
-
-        match cluster.relative_message_redundancy() {
-            Ok(result) => {
-                stats.insert_rmr(result);
-            },
-            Err(_) => error!("Network RMR error. # of nodes is 1."),
-        }
-
-        stats.calculate_outbound_branching_factor(cluster.get_pushes());
-        stats.calculate_inbound_branching_factor(cluster.get_orders());
 
         cluster.consume_messages(origin_pubkey, &mut nodes);
         cluster.send_prunes(*origin_pubkey, &mut nodes, config.prune_stake_threshold, config.min_ingress_nodes, &stakes);
@@ -370,16 +333,48 @@ fn run_simulation(config: &Config, matches: &ArgMatches, gossip_stats_collection
                 .iter()
                 .map(|node| (node.pubkey(), node))
                 .collect();
-            cluster.prune_connections(&node_map, &stakes);
+            cluster.prune_connections(&node_map, &stakes, i);
         }
 
         let mut rng = rand::thread_rng();
         cluster.chance_to_rotate(&mut rng, &mut nodes, config.gossip_active_set_size, &stakes, config.probability_of_rotation, &mut StdRng::from_entropy());
-    }
 
-    stats.run_all_calculations(config.num_buckets_for_stranded_node_hist);
-    // stats.print_all();
-    gossip_stats_collection.push(stats.clone());
+        // wait until after set number of warmup rounds to begin calculating gossip stats
+        if i >= config.warm_up_rounds {
+            let (coverage, stranded_nodes) = cluster.coverage(&stakes);
+            debug!("For origin {:?}, the cluster coverage is: {:.6}", origin_pubkey, coverage);
+            debug!("{} nodes are stranded", stranded_nodes);
+            if coverage < poor_coverage_threshold {
+                warn!("WARNING: poor coverage for origin: {:?}, {}", origin_pubkey, coverage);
+                _number_of_poor_coverage_runs += 1;
+            }
+
+            stats.insert_coverage(coverage);
+            stats.insert_hops_stat(cluster.get_distances());
+
+            match cluster.relative_message_redundancy() {
+                Ok(result) => {
+                    stats.insert_rmr(result);
+                },
+                Err(_) => error!("Network RMR error. # of nodes is 1."),
+            }
+
+            stats.insert_stranded_nodes(
+                &cluster.stranded_nodes(), 
+                &stakes
+            );
+            
+            if log::log_enabled!(Level::Debug) {
+                cluster.print_pushes();
+            }
+
+            stats.calculate_outbound_branching_factor(cluster.get_pushes());
+        }
+    }
+    if !stats.is_empty() {
+        stats.run_all_calculations(config.num_buckets_for_stranded_node_hist);
+        gossip_stats_collection.push(stats.clone());
+    }
 }
 
 fn main() {
@@ -432,7 +427,14 @@ fn main() {
                             })
                     })
                     .unwrap(),
+        warm_up_rounds: value_t_or_exit!(matches, "warm_up_rounds", usize),
     };
+
+    if config.gossip_iterations <= config.warm_up_rounds {
+        warn!("WARNING: Gossip Iterations ({}) <= Warm Up Rounds ({}). No stats will be recorded....", 
+            config.gossip_iterations, 
+            config.warm_up_rounds);
+    }
 
     let mut gossip_stats_collection = GossipStatsCollection::default();
     gossip_stats_collection.set_number_of_simulations(config.num_simulations);
@@ -521,8 +523,11 @@ fn main() {
         }
     }
 
-    gossip_stats_collection.print_all(config.gossip_iterations, config.test_type);
-
+    if !gossip_stats_collection.is_empty() {
+        gossip_stats_collection.print_all(config.gossip_iterations, config.warm_up_rounds, config.test_type);
+    } else {
+        warn!("WARNING: Gossip Stats Collection is empty. Is `Iterations` <= `warm-up-rounds`?");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
dont start measuring gossip stats until warm-up-rounds has executed. Avoids measuring stats for the transient MST setup at the beginning of gossip. 

Also remove inbound branch degree. same as outbound for directed graph