### PR TITLE
fix influx reporting bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ cargo run --bin gossip-sim --
     --filter-zero-staked-nodes
     --num-buckets <num-buckets-for-histogram>
     --warm-up-rounds <warm_up_rounds>
+    --print-stats
 ```
-Note: `warm-up-rounds` sets the number of gossip iterations to run before collecting gossip statistics [default: 200]. It allows gossip to reach a sort of steady state. Without this, Gossip Statistics will include transient stats measued during the initial creation of the MST.
+- Note: `warm-up-rounds` sets the number of gossip iterations to run before collecting gossip statistics [default: 200]. It allows gossip to reach a sort of steady state. Without this, Gossip Statistics will include transient stats measued during the initial creation of the MST.
+- Note: `print-stats` is a flag that will print out all of the gossip stats in the simulation to console
 
 #### Option 3: Pull accounts from mainnet and run simulation
 - This will pull all node accounts from mainnet and simulate the network.

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -110,6 +110,7 @@ pub struct Config<'a> {
     pub num_simulations: usize,
     pub step_size: StepSize,
     pub warm_up_rounds: usize,
+    pub print_stats: bool,
 }
 
 pub struct Cluster {

--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -450,6 +450,10 @@ fn run_simulation(
             // }
         }
     }
+    let mut datapoint = InfluxDataPoint::default();
+    datapoint.set_last_datapoint();
+    datapoint_queue.lock().unwrap().push_back(datapoint);
+
     if !stats.is_empty() {
         stats.run_all_calculations(config.num_buckets_for_stranded_node_hist);
         gossip_stats_collection.push(stats.clone());
@@ -520,6 +524,7 @@ fn main() {
 
     let datapoint_queue: Arc<Mutex<VecDeque<InfluxDataPoint>>> = Arc::new(Mutex::new(VecDeque::new()));
     let influx_db_queue = datapoint_queue.clone();
+
     if let Err(err) = load_influx_env_vars() {
         error!("Failed to load environment variables: {}", err);
         return;

--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -24,7 +24,7 @@ use {
     std::{
         fs::{File}, 
         path::Path, 
-        collections::{HashMap, BinaryHeap},
+        collections::{HashMap, BinaryHeap, VecDeque},
         process::exit,
         cmp::Reverse,
         env,
@@ -497,6 +497,8 @@ fn main() {
             config.gossip_iterations, 
             config.warm_up_rounds);
     }
+
+    let datapoint_queue: VecDeque<Inf>
 
     // check if we are going to push data to influx
     // if --influx set, we are pushing to influx

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -19,7 +19,8 @@ use {
 pub struct ReportToInflux {}
 
 impl ReportToInflux {
-    pub fn send(
+    #[tokio::main]
+    pub async fn send(
         url: Url,
         database: String,
         username: String,
@@ -39,26 +40,27 @@ impl ReportToInflux {
                 .basic_auth(username, Some(password))
                 .query(&[("db", database.as_str())])
                 .body(data_point)
-                .send();
-                // .await;
+                .send()
+                .await;
         
         info!("suhhhh");
 
-        // match response {
-        //     Ok(response) => {
-        //         if response.status().is_success() {
-        //             trace!("Data successfully reported to InfluxDB");
-        //         } else {
-        //             error!("Failed to report data to InfluxDB. Status: {}", response.status());
-        //         }
-        //     }
-        //     Err(err) => {
-        //         error!("Error reporting to InfluxDB: {}", err);
-        //     }
-        // }
+        match response {
+            Ok(response) => {
+                if response.status().is_success() {
+                    trace!("Data successfully reported to InfluxDB");
+                } else {
+                    error!("Failed to report data to InfluxDB. Status: {}", response.status());
+                }
+            }
+            Err(err) => {
+                error!("Error reporting to InfluxDB: {}", err);
+            }
+        }
     }
 
-    pub fn sender(
+    #[tokio::main]
+    pub async fn sender(
         url: Url,
         database: String,
         username: String,
@@ -66,9 +68,11 @@ impl ReportToInflux {
         data_point: String,
     ) {
         info!("in sender(): ");
-
+        async_std::task::spawn(async move {
+            ReportToInflux::send(url, database, username, password, data_point);
+        });
         // async_std::task::spawn(async move {
-        let _ = ReportToInflux::send(url, database, username, password, data_point);
+        // let _ = ReportToInflux::send(url, database, username, password, data_point);
         // });
 
     }

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -168,16 +168,12 @@ impl InfluxThread {
 
         loop {
             let datapoint = datapoint_queue.lock().unwrap().pop_front();
-            // info!("wait time: {}", wait_time.as_millis());
             if let Some(dp) = datapoint {
-                // info!("front val: {}", dp.data());
                 if dp.last_datapoint() {
                     rx_last_datapoint = true;
                 } else if dp.is_start(){
-                    // info!("start received!");
                     wait_time = std::time::Duration::from_millis(1);
                 } else {
-                    // info!("not last datapoint");
                     influx_db.send_data_points(dp);
     
                     unsafe {
@@ -193,10 +189,9 @@ impl InfluxThread {
                     info!("Last simulation datapoint recorded. Draining Queue...")
                 }
                 unsafe {
-                    // info!("Waiting to drain queue...");
                     if let Some(ref t) = TRACKER {
                         if t.lock().unwrap().equal() {
-                            // info!("Queue Drained. Exiting...");
+                            info!("Queue Drained. Exiting...");
                             break;
                         }
                     } 

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -2,26 +2,36 @@ use {
     url::Url,
     reqwest,
     tokio,
-    log::{error, debug, trace},
+    log::{error, info, debug, trace},
     crate::gossip_stats::{
         HopsStat,
         StrandedNodeStats,
     },
+    std::{
+        time::{SystemTime, UNIX_EPOCH},
+        sync::{Arc, Mutex},
+        collections::VecDeque,
+        thread,
+    },
+
 };
 
 pub struct ReportToInflux {}
 
 impl ReportToInflux {
-    #[tokio::main]
-    pub async fn send(
+    pub fn send(
         url: Url,
         database: String,
         username: String,
         password: String, 
         data_point: String,
     ) {
+        info!("in send!");
         let client = reqwest::Client::new();
         let influx_url = url.join("write").unwrap();
+
+        info!("about to send: data_point: {}", data_point);
+        info!("url: {:?}", url);
 
         let response = 
             client
@@ -29,44 +39,84 @@ impl ReportToInflux {
                 .basic_auth(username, Some(password))
                 .query(&[("db", database.as_str())])
                 .body(data_point)
-                .send()
-                .await;
+                .send();
+                // .await;
+        
+        info!("suhhhh");
 
-        match response {
-            Ok(response) => {
-                if response.status().is_success() {
-                    trace!("Data successfully reported to InfluxDB");
-                } else {
-                    error!("Failed to report data to InfluxDB. Status: {}", response.status());
-                }
-            }
-            Err(err) => {
-                error!("Error reporting to InfluxDB: {}", err);
-            }
-        }
+        // match response {
+        //     Ok(response) => {
+        //         if response.status().is_success() {
+        //             trace!("Data successfully reported to InfluxDB");
+        //         } else {
+        //             error!("Failed to report data to InfluxDB. Status: {}", response.status());
+        //         }
+        //     }
+        //     Err(err) => {
+        //         error!("Error reporting to InfluxDB: {}", err);
+        //     }
+        // }
     }
 
-    #[tokio::main]
-    pub async fn sender(
+    pub fn sender(
         url: Url,
         database: String,
         username: String,
         password: String, 
         data_point: String,
     ) {
-        async_std::task::spawn(async move {
-            ReportToInflux::send(url, database, username, password, data_point);
-        });
+        info!("in sender(): ");
+
+        // async_std::task::spawn(async move {
+        let _ = ReportToInflux::send(url, database, username, password, data_point);
+        // });
 
     }
+
 }
 
+pub struct InfluxThread { }
+
+impl InfluxThread {
+    pub fn start(
+        endpoint: &str,
+        database: String,
+        username: String,
+        password: String,
+        datapoint_queue: Arc<Mutex<VecDeque<InfluxDataPoint>>>,
+    ) {
+        let influx_db = InfluxDB::new(
+            endpoint,
+            database,
+            username,
+            password
+        ).unwrap();
+
+        loop {
+            let datapoint = datapoint_queue.lock().unwrap().pop_front();
+            
+            if let Some(dp) = datapoint {
+                info!("front val: {}", dp.data());
+                if dp.last_datapoint() {
+                    info!("Last data point, returning");
+                    break;
+                }
+
+                info!("not last datapoint");
+                influx_db.send_data_points(dp);
+
+            } else {
+                info!("deque empty");
+            }
+            thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct InfluxDB {
     url: Url,
     database: String,
-    datapoints: String,
     username: String,
     password: String,
 }
@@ -84,72 +134,116 @@ impl InfluxDB {
             Self { 
                 url,
                 database: database,
-                datapoints: "".to_string(),
                 username: username,
                 password: password,
             }
         )
     }
 
-    pub fn send_data_points(
+    fn send_data_points(
         &self,
+        datapoint: InfluxDataPoint,
     ) {
-        debug!("datapoint: {:?}", self.datapoints);
+        debug!("datapoint: {:?}", datapoint);
 
         let url = self.url.clone();
         let database = self.database.clone();
-        let datapoints = self.datapoints.clone();
+        // let datapoints = self.datapoints.clone();
         let username = self.username.clone();
         let password = self.password.clone();
 
-        ReportToInflux::sender(url, database, username, password, datapoints);
+        info!("sending to sender: ");
+        let _ = ReportToInflux::sender(url, database, username, password, datapoint.data());
+    }
+
+
+}
+
+#[derive(Clone, Debug)]
+pub struct InfluxDataPoint {
+    datapoint: String,
+}
+
+impl Default for InfluxDataPoint {
+    fn default() -> Self {
+        InfluxDataPoint {
+            datapoint: "".to_string(),
+        }
+    }
+}
+
+impl InfluxDataPoint {
+    pub fn data(
+        &self,
+    ) -> String {
+        self.datapoint.clone()
+    }
+
+    pub fn set_last_datapoint(
+        &mut self,
+    ) {
+        self.datapoint.push_str("end");
+    }
+
+    pub fn last_datapoint(
+        &self,
+    ) -> bool {
+        if self.datapoint == "end" {
+            return true;
+        }
+        false
+    }
+
+    pub fn get_timestamp_now(
+        &self,
+    ) -> String {
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        format!("{}\n", ts)
+    }
+
+    pub fn append_timestamp(
+        &mut self,
+    ) {
+        self.datapoint.push_str(self.get_timestamp_now().as_str());
     }
 
     pub fn create_data_point(
         &mut self,
         data: f64,
         stat_type: String,
-        gossip_iteration: usize,
-        simulation_iteration: usize,
     ) {
-        let data_point = format!("{} simulation_iter={},gossip_iter={},data={}\n",
+        let data_point = format!("{} data={} ",
             stat_type, 
-            simulation_iteration,
-            gossip_iteration,
-            data);
-        
-        self.datapoints.push_str(data_point.as_str());
+            data
+        );        
+        self.datapoint.push_str(data_point.as_str());
     }
 
     pub fn create_hops_stat_point(
         &mut self,
         data: &HopsStat,
-        gossip_iteration: usize,
-        simulation_iteration: usize,
     ) {
 
-        let data_point = format!("{} simulation_iter={},gossip_iter={},mean={},median={},max={}\n",
+        let data_point = format!("{} mean={},median={},max={}\n",
             "hops_stat".to_string(), 
-            simulation_iteration,
-            gossip_iteration,
             data.mean(),
             data.median(),
             data.max()
         );
 
-        self.datapoints.push_str(data_point.as_str());
+        self.datapoint.push_str(data_point.as_str());
     }
 
     pub fn create_stranded_node_stat_point(
         &mut self,
         data: &StrandedNodeStats,
-        gossip_iteration: usize,
-        simulation_iteration: usize,
     ) {
-        let data_point = format!("{} simulation_iter={},gossip_iter={},count={},mean={},median={},max={},min={}\n",
-            "stranded_node_stats".to_string(), 
-            simulation_iteration,
-            gossip_iteration,
+        let data_point = format!("{} count={},mean={},median={},max={},min={}\n",
+            "stranded_node_stats".to_string(),
             data.count(),
             data.mean(),
             data.median(),
@@ -157,6 +251,37 @@ impl InfluxDB {
             data.min(),
         );
 
-        self.datapoints.push_str(data_point.as_str());
+        self.datapoint.push_str(data_point.as_str());
+    }
+
+    pub fn create_iteration_point(
+        &mut self,
+        gossip_iter: usize,
+        simulation_iter: usize,
+    ) {
+        let data_point = format!("iteration simulation_iter={},gossip_iter={} ", 
+            simulation_iter, 
+            gossip_iter
+        );
+        self.datapoint.push_str(data_point.as_str());
+    }
+
+    pub fn create_config_point(
+        &mut self,
+        push_fanout: usize,
+        active_set_size: usize,
+        origin_rank: usize,
+        prune_stake_threshold: f64,
+        min_ingress_nodes: usize,
+    ) {
+        let data_point = format!("config push_fanout={},active_set_size={},origin_rank={},prune_stake_threshold={},min_ingress_nodes={}\n",
+            push_fanout, 
+            active_set_size,
+            origin_rank,
+            prune_stake_threshold,
+            min_ingress_nodes
+        );
+
+        self.datapoint.push_str(data_point.as_str());
     }
 }


### PR DESCRIPTION
- fix bug in influx. Not all datapoints were being reported to influx and some reported out of order
- FIX: change to a shared queue model between gossip-thread and a influx reporting thread. Gossip writes into shared queue, reporting thread reads from queue and sends data to influx. Waits until all data is sent before returning.

- Add in `--print-stats` flag that, if set, will print out the simulations tats to console. if not set, no stats will be printed.