### PR TITLE
Rotate prob

### DIFF
--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -37,6 +37,7 @@ pub enum Testing {
     PruneStakeThreshold,
     OriginRank,
     FailNodes,
+    RotateProbability,
     NoTest,
 }
 
@@ -49,6 +50,7 @@ impl std::fmt::Display for Testing {
             Testing::PruneStakeThreshold => write!(f, "PruneStakeThreshold"),
             Testing::OriginRank => write!(f, "OriginRank"),
             Testing::FailNodes => write!(f, "FailNodes"),
+            Testing::RotateProbability => write!(f, "RotateProbability"),
             Testing::NoTest => write!(f, "NoTest"),
         }
     }
@@ -65,6 +67,7 @@ impl FromStr for Testing {
             "prune-stake-threshold" => Ok(Testing::PruneStakeThreshold),
             "origin-rank" => Ok(Testing::OriginRank),
             "fail-nodes" => Ok(Testing::FailNodes),
+            "rotate-probability" => Ok(Testing::RotateProbability),
             "no-test" => Ok(Testing::NoTest),
             _ => Err(format!("Invalid test type: {}", s)),
         }

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -455,6 +455,7 @@ impl InfluxDataPoint {
         prune_stake_threshold: f64,
         min_ingress_nodes: usize,
         fraction_to_fail: f64,
+        rotation_probability: f64,
     ) {
         self.datapoint.push_str(
             format!("config,simulation_iter={} \
@@ -463,14 +464,16 @@ impl InfluxDataPoint {
                 origin_rank={},\
                 prune_stake_threshold={},\
                 min_ingress_nodes={},\
-                fraction_to_fail={} ",
+                fraction_to_fail={},\
+                rotation_probability={} ",
                     self.simulation_iteration,
                     push_fanout, 
                     active_set_size,
                     origin_rank,
                     prune_stake_threshold,
                     min_ingress_nodes,
-                    fraction_to_fail
+                    fraction_to_fail,
+                    rotation_probability,
             ).as_str()
         );
         self.append_timestamp();


### PR DESCRIPTION
add in rotate probability test to gossip sim
test various rotate active set probabilities to simulate changes in active sets like in solana