### PR TITLE
add in rotate probability test and group by simulation iter

### DIFF
--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -37,6 +37,7 @@ pub enum Testing {
     PruneStakeThreshold,
     OriginRank,
     FailNodes,
+    RotateProbability,
     NoTest,
 }
 
@@ -49,6 +50,7 @@ impl std::fmt::Display for Testing {
             Testing::PruneStakeThreshold => write!(f, "PruneStakeThreshold"),
             Testing::OriginRank => write!(f, "OriginRank"),
             Testing::FailNodes => write!(f, "FailNodes"),
+            Testing::RotateProbability => write!(f, "RotateProbability"),
             Testing::NoTest => write!(f, "NoTest"),
         }
     }
@@ -65,6 +67,7 @@ impl FromStr for Testing {
             "prune-stake-threshold" => Ok(Testing::PruneStakeThreshold),
             "origin-rank" => Ok(Testing::OriginRank),
             "fail-nodes" => Ok(Testing::FailNodes),
+            "rotate-probability" => Ok(Testing::RotateProbability),
             "no-test" => Ok(Testing::NoTest),
             _ => Err(format!("Invalid test type: {}", s)),
         }

--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -377,7 +377,7 @@ fn run_simulation(
             info!("MST ITERATION: {}", gossip_iteration);
             match datapoint_queue {
                 Some(dp_queue) => {
-                    let mut datapoint = InfluxDataPoint::default();
+                    let mut datapoint = InfluxDataPoint::new(simulation_iteration);
                     datapoint.create_config_point(
                         config.gossip_push_fanout,
                         config.gossip_active_set_size,
@@ -449,7 +449,7 @@ fn run_simulation(
 
             match datapoint_queue {
                 Some(dp_queue) => {
-                    let mut datapoint = InfluxDataPoint::default();
+                    let mut datapoint = InfluxDataPoint::new(simulation_iteration);
                     match cluster.relative_message_redundancy() {
                         Ok(result) => {
                             stats.insert_rmr(result);
@@ -480,7 +480,7 @@ fn run_simulation(
         
                     datapoint.create_iteration_point(
                         steady_state_iteration, 
-                        simulation_iteration
+                        simulation_iteration,
                     );
                     dp_queue.lock().unwrap().push_back(datapoint);
                 }
@@ -508,6 +508,12 @@ fn run_simulation(
                     0,
                     25
             );
+        } else if config.test_type == Testing::MinIngressNodes {
+            stats.build_aggregate_hops_stats_histogram(
+                50,
+                    0,
+                    25
+            );
         } else {
             stats.build_aggregate_hops_stats_histogram(30, 0, 15);
         }
@@ -517,7 +523,7 @@ fn run_simulation(
 
         match datapoint_queue {
             Some(dp_queue) => {
-                let mut datapoint = InfluxDataPoint::default();
+                let mut datapoint = InfluxDataPoint::new(simulation_iteration);
                 let data = stats.get_stranded_node_iteration_data();
                 datapoint.create_stranded_iteration_point(
                     data.0,

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -455,6 +455,7 @@ impl InfluxDataPoint {
         prune_stake_threshold: f64,
         min_ingress_nodes: usize,
         fraction_to_fail: f64,
+        rotation_probability: f64,
     ) {
         self.datapoint.push_str(
             format!("config,simulation_iter={} \
@@ -463,14 +464,16 @@ impl InfluxDataPoint {
                 origin_rank={},\
                 prune_stake_threshold={},\
                 min_ingress_nodes={},\
-                fraction_to_fail={} ",
+                fraction_to_fail={},\
+                rotation_probability={} ",
                     self.simulation_iteration,
                     push_fanout, 
                     active_set_size,
                     origin_rank,
                     prune_stake_threshold,
                     min_ingress_nodes,
-                    fraction_to_fail
+                    fraction_to_fail,
+                    rotation_probability,
             ).as_str()
         );
         self.append_timestamp();


### PR DESCRIPTION
we can now test how rotation probability affects gossip. and can get averages and stuff over entire simulations since we now report simulation iteration with each datapoint so we can group by it