### PR TITLE
Add Egress Message Tracking by Node Stake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ tokio = { version = "~1.14.1", features = ["full"] }
 dotenv = "0.15.0"
 async-std = "1.12.0"
 
-
 [dev-dependencies]
 rand_chacha = "0.2.2"
 

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -121,6 +121,8 @@ pub struct Config<'a> {
     pub min_ingress_nodes: usize,
     pub filter_zero_staked_nodes: bool,
     pub num_buckets_for_stranded_node_hist: u64,
+    pub num_buckets_for_egress_message_hist: u64,
+    pub num_buckets_for_hops_stats_hist: u64,
     pub fraction_to_fail: f64,
     pub when_to_fail: usize,
     pub test_type: Testing,

--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -420,6 +420,9 @@ fn run_simulation(
 
         cluster.chance_to_rotate(&mut nodes, config.gossip_active_set_size, &stakes, config.probability_of_rotation);
 
+        if gossip_iteration + 1 == config.warm_up_rounds {
+            cluster.get_egress_messages().clear();
+        }
 
         // wait until after warmup rounds to begin calculating gossip stats and reporting to influx
         if gossip_iteration >= config.warm_up_rounds {

--- a/src/gossip_stats.rs
+++ b/src/gossip_stats.rs
@@ -66,9 +66,12 @@ impl HopsStat {
             .sum::<u64>() as f64 / count as f64;
 
         // Calculate the median
-        let median = if count % 2 == 0 {
+        let median = if count == 0 {
+            0.0
+        } else if count == 1 {
+            hops[0] as f64
+        } else if count % 2 == 0 {
             let mid = count / 2;
-
             (hops[mid - 1] + hops[mid]) as f64 / 2.0
         } else {
             hops[count / 2] as f64

--- a/src/gossip_stats.rs
+++ b/src/gossip_stats.rs
@@ -405,8 +405,9 @@ impl EgressMessages {
         }
 
         let upper_bound = stakes_vec[0].1; // highest stake
-        let lower_bound = stakes_vec[stakes_vec.len() - 1].1; //lowest stake
-        let num_buckets = 100;
+        // let lower_bound = stakes_vec[stakes_vec.len() - 1].1; //lowest stake
+        let lower_bound = 0;
+        let num_buckets = 100; // TODO: make configurable
         let bucket_range: u64;
 
         if upper_bound == lower_bound || lower_bound + 1 == upper_bound {

--- a/src/gossip_stats.rs
+++ b/src/gossip_stats.rs
@@ -374,15 +374,6 @@ pub struct EgressMessages {
     // histogram: Histogram,  // i actually don't think we can use our histogram class.
 }
 
-// impl Default for EgressMessages {
-//     fn default() -> Self {
-//         Self {
-//             counts: HashMap::default(),
-//             histogram: Histogram::default(),
-//         }
-//     }
-// }
-
 impl EgressMessages {
     pub fn new(
         stakes: &HashMap<Pubkey, u64>,
@@ -410,7 +401,7 @@ impl EgressMessages {
 
         // let lower_bound = stakes_vec[stakes_vec.len() - 1].1; //lowest stake
         let lower_bound = 0;
-        let num_buckets = 100; // TODO: make configurable
+        let num_buckets = 20; // TODO: make configurable
         let bucket_range: u64;
 
         if upper_bound == lower_bound || lower_bound + 1 == upper_bound {
@@ -475,7 +466,7 @@ impl EgressMessages {
 
             if *stake >= self.min_entry && *stake <= self.max_entry {
                 let bucket: u64 = (*stake - self.min_entry) / self.bucket_range;
-                info!("pubkey, stake, bucket, msgs: {:?}, {}, {}, {}", pubkey, stake, bucket, egress_messages);
+                // info!("pubkey, stake, bucket, msgs: {:?}, {}, {}, {}", pubkey, stake, bucket, egress_messages);
                 // add total egress messages to bucket entry.
                 // if bucket entry doesn't exist, begin it with the current egress_messages count
                 *self.entries.entry(bucket).or_insert(0) += *egress_messages;

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -564,7 +564,7 @@ impl InfluxDataPoint {
             self.set_and_append_timestamp();
         }
 
-        info!("egress histogram point: {}", self.datapoint);
+        debug!("egress histogram point: {}", self.datapoint);
     }
 
 

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -7,7 +7,6 @@ use {
         HopsStat,
         StrandedNodeStats,
         Histogram,
-        EgressMessages,
     },
     crate::gossip::{
         Testing,
@@ -550,24 +549,17 @@ impl InfluxDataPoint {
         debug!("histogram point: {}", self.datapoint);
     }
 
-    // this is really a histogram. needs refactor
+    // for egress message histogram, since the x axis is percentage of stake
+    // We want to pass in the actual bucket values instead of the stake values
+    // that way when we see bucket 1, we know that that is the lowest 1-2% of all 
+    // staked nodes in the network
     pub fn create_egress_messages_point(
         &mut self,
-        egress_messages: &EgressMessages,
+        egress_messages: &Histogram,
         simulation_iter_val: usize,
     ) {
         for (bucket, egress_count) in egress_messages.entries().iter() {
-            // let bucket_min = egress_messages.min_entry() + bucket * egress_messages.bucket_range();
-            // let bucket_max = egress_messages.min_entry() + (bucket + 1) * egress_messages.bucket_range() - 1;
-            // if bucket_min == bucket_max {
-            //     debug!("Bucket: {}: Message Count: {}", bucket_max, egress_count);
-            // } else {
-            //     debug!("Bucket: {}-{}: Message Count: {}", bucket_min, bucket_max, egress_count);
-            // }
-            // let data_point  = format!("egress_message_count,simulation_iter={} bucket={},count={} ", simulation_iter_val, bucket_max / 1000000000 , egress_count);
             let data_point  = format!("egress_message_count,simulation_iter={} bucket={},count={} ", simulation_iter_val, bucket , egress_count);
-
-
             self.datapoint.push_str(data_point.as_str());
             self.set_and_append_timestamp();
         }

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -7,6 +7,7 @@ use {
         HopsStat,
         StrandedNodeStats,
         Histogram,
+        EgressMessages,
     },
     crate::gossip::{
         Testing,
@@ -546,6 +547,29 @@ impl InfluxDataPoint {
         }
 
         debug!("histogram point: {}", self.datapoint);
+    }
+
+    // this is really a histogram. needs refactor
+    pub fn create_egress_messages_point(
+        &mut self,
+        egress_messages: &EgressMessages,
+        simulation_iter_val: usize,
+    ) {
+        for (bucket, egress_count) in egress_messages.entries().iter() {
+            let bucket_min = egress_messages.min_entry() + bucket * egress_messages.bucket_range();
+            let bucket_max = egress_messages.min_entry() + (bucket + 1) * egress_messages.bucket_range() - 1;
+            if bucket_min == bucket_max {
+                debug!("Bucket: {}: Message Count: {}", bucket_max, egress_count);
+            } else {
+                debug!("Bucket: {}-{}: Message Count: {}", bucket_min, bucket_max, egress_count);
+            }
+            let data_point  = format!("egress_message_count,simulation_iter={} bucket={},count={} ", simulation_iter_val, bucket_max, egress_count);
+
+            self.datapoint.push_str(data_point.as_str());
+            self.set_and_append_timestamp();
+        }
+
+        info!("egress histogram point: {}", self.datapoint);
     }
 
 


### PR DESCRIPTION
Goal: 
We want to know how the number of egress messages increases if we change different gossip parameters. We want to know this number based on the stake of each node. Highly staked nodes incur the highest egress message overhead, so we don't want to increase the number of messages they send by too much.

What:
This pull request creates a histogram where buckets are the fractional stake of each node. So for a histogram of 100 buckets, bucket 0 is the lowest 1% of staked nodes. Bucket 99 is the highest 1% of staked nodes. The count is the total number of messages sent by all nodes that fall into each individual bucket.

This histogram data is sent to grafana where it can be visualized. 

Also fixes a bug in median calculation when sample sizes are 1 or 0. 