### PR TITLE
Add Node stake distribution histogram to influx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ tokio = { version = "~1.14.1", features = ["full"] }
 dotenv = "0.15.0"
 async-std = "1.12.0"
 
-
 [dev-dependencies]
 rand_chacha = "0.2.2"
 

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -416,11 +416,11 @@ impl Cluster {
     // if calculated return it. 
     pub fn relative_message_redundancy(
         &mut self,
-    ) -> Result<f64, String> {
+    ) -> Result<(f64, u64, u64), String> {
         if self.rmr.rmr() == 0.0 {
             self.rmr.calculate_rmr()
         } else {
-            Ok(self.rmr.rmr())
+            Ok((self.rmr.rmr(), self.rmr.total_messages_sent(), self.rmr.total_nodes_that_received_message()))
         }
     }
 

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -121,6 +121,8 @@ pub struct Config<'a> {
     pub min_ingress_nodes: usize,
     pub filter_zero_staked_nodes: bool,
     pub num_buckets_for_stranded_node_hist: u64,
+    pub num_buckets_for_egress_message_hist: u64,
+    pub num_buckets_for_hops_stats_hist: u64,
     pub fraction_to_fail: f64,
     pub when_to_fail: usize,
     pub test_type: Testing,

--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -38,6 +38,12 @@ use {
     rand::SeedableRng,
     rayon::prelude::*,
     dotenv::dotenv,
+    gossip_sim::{
+        AGGREGATE_HOPS_FAIL_NODES_HISTOGRAM_UPPER_BOUND,
+        AGGREGATE_HOPS_MIN_INGRESS_NODES_HISTOGRAM_UPPER_BOUND,
+        STANDARD_HISTOGRAM_UPPER_BOUND,
+        VALIDATOR_STAKE_DISTRIBUTION_NUM_BUCKETS,
+    }
 };
 
 fn parse_matches() -> ArgMatches {
@@ -347,7 +353,10 @@ fn run_simulation(
     stats.set_simulation_parameters(config);
     stats.set_origin(*origin_pubkey);
     stats.initialize_message_stats(&stakes);
-    stats.build_validator_stake_distribution_histogram(100, &stakes);
+    stats.build_validator_stake_distribution_histogram(
+        VALIDATOR_STAKE_DISTRIBUTION_NUM_BUCKETS, 
+        &stakes
+    );
 
     if simulation_iteration == 0 {
         match datapoint_queue {
@@ -537,18 +546,18 @@ fn run_simulation(
         );
         if config.test_type == Testing::FailNodes {
             stats.build_aggregate_hops_stats_histogram(
-                (40.0 * (1.0 + config.fraction_to_fail)) as u64,
+                (AGGREGATE_HOPS_FAIL_NODES_HISTOGRAM_UPPER_BOUND * (1.0 + config.fraction_to_fail)) as u64,
                     0,
                     config.num_buckets_for_hops_stats_hist // 25  
             );
         } else if config.test_type == Testing::MinIngressNodes {
             stats.build_aggregate_hops_stats_histogram(
-                50,
-                    0,
-                    config.num_buckets_for_hops_stats_hist //25
+                AGGREGATE_HOPS_MIN_INGRESS_NODES_HISTOGRAM_UPPER_BOUND,
+                0,
+                config.num_buckets_for_hops_stats_hist //25
             );
         } else {
-            stats.build_aggregate_hops_stats_histogram(30, 0, config.num_buckets_for_hops_stats_hist);
+            stats.build_aggregate_hops_stats_histogram(STANDARD_HISTOGRAM_UPPER_BOUND, 0, config.num_buckets_for_hops_stats_hist);
         }
 
         stats.build_message_histograms(config.num_buckets_for_message_hist, true, &stakes);

--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -454,10 +454,9 @@ fn run_simulation(
                     let mut datapoint = InfluxDataPoint::new(simulation_iteration);
                     match cluster.relative_message_redundancy() {
                         Ok(result) => {
-                            stats.insert_rmr(result);
-                            datapoint.create_data_point(
-                                result, 
-                                "rmr".to_string()
+                            stats.insert_rmr(result.0);
+                            datapoint.create_rmr_data_point(
+                                result
                             );
                         },
                         Err(_) => error!("Network RMR error. # of nodes is 1."),
@@ -489,7 +488,7 @@ fn run_simulation(
                 None => {
                     match cluster.relative_message_redundancy() {
                         Ok(result) => {
-                            stats.insert_rmr(result);
+                            stats.insert_rmr(result.0);
                         },
                         Err(_) => error!("Network RMR error. # of nodes is 1."),
                     }

--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -347,7 +347,7 @@ fn run_simulation(
     stats.set_simulation_parameters(config);
     stats.set_origin(*origin_pubkey);
     stats.initialize_message_stats(&stakes);
-    stats.build_validator_stake_distribution_histogram(10, &stakes);
+    stats.build_validator_stake_distribution_histogram(100, &stakes);
 
     if simulation_iteration == 0 {
         match datapoint_queue {

--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -420,6 +420,9 @@ fn run_simulation(
 
         cluster.chance_to_rotate(&mut nodes, config.gossip_active_set_size, &stakes, config.probability_of_rotation);
 
+        if gossip_iteration + 1 == config.warm_up_rounds {
+            cluster.get_egress_messages().clear();
+        }
 
         // wait until after warmup rounds to begin calculating gossip stats and reporting to influx
         if gossip_iteration >= config.warm_up_rounds {

--- a/src/gossip_stats.rs
+++ b/src/gossip_stats.rs
@@ -394,13 +394,13 @@ impl RelativeMessageRedundancy {
 
     pub fn calculate_rmr(
         &mut self,
-    ) -> Result<f64, String> {
+    ) -> Result<(f64, u64, u64), String> {
         if self.n == 0 {
             Err("Division by zero. n is 0.".to_string())
         } else {
             self.rmr = self.m as f64 / (self.n - 1) as f64 - 1.0;
             trace!("RMR: {}, m: {}, n: {}", self.rmr, self.m, self.n);
-            Ok(self.rmr)
+            Ok((self.rmr, self.m, self.n))
         }
     }
 
@@ -408,6 +408,18 @@ impl RelativeMessageRedundancy {
         &self,
     ) -> f64 {
         self.rmr
+    }
+
+    pub fn total_messages_sent(
+        &self,
+    ) -> u64 {
+        self.m
+    }
+
+    pub fn total_nodes_that_received_message(
+        &self,
+    ) -> u64 {
+        self.n
     }
 
 }
@@ -1801,7 +1813,7 @@ mod tests {
 
             match cluster.relative_message_redundancy() {
                 Ok(result) => {
-                    gossip_stats.insert_rmr(result);
+                    gossip_stats.insert_rmr(result.0);
                 },
                 Err(_) => error!("Network RMR error. # of nodes is 1."),
             }

--- a/src/gossip_stats.rs
+++ b/src/gossip_stats.rs
@@ -66,9 +66,12 @@ impl HopsStat {
             .sum::<u64>() as f64 / count as f64;
 
         // Calculate the median
-        let median = if count % 2 == 0 {
+        let median = if count == 0 {
+            0.0
+        } else if count == 1 {
+            hops[0] as f64
+        } else if count % 2 == 0 {
             let mid = count / 2;
-
             (hops[mid - 1] + hops[mid]) as f64 / 2.0
         } else {
             hops[count / 2] as f64

--- a/src/gossip_stats.rs
+++ b/src/gossip_stats.rs
@@ -405,8 +405,9 @@ impl EgressMessages {
         }
 
         let upper_bound = stakes_vec[0].1; // highest stake
-        let lower_bound = stakes_vec[stakes_vec.len() - 1].1; //lowest stake
-        let num_buckets = 100;
+        // let lower_bound = stakes_vec[stakes_vec.len() - 1].1; //lowest stake
+        let lower_bound = 0;
+        let num_buckets = 100; // TODO: make configurable
         let bucket_range: u64;
 
         if upper_bound == lower_bound || lower_bound + 1 == upper_bound {

--- a/src/gossip_stats.rs
+++ b/src/gossip_stats.rs
@@ -374,15 +374,6 @@ pub struct EgressMessages {
     // histogram: Histogram,  // i actually don't think we can use our histogram class.
 }
 
-// impl Default for EgressMessages {
-//     fn default() -> Self {
-//         Self {
-//             counts: HashMap::default(),
-//             histogram: Histogram::default(),
-//         }
-//     }
-// }
-
 impl EgressMessages {
     pub fn new(
         stakes: &HashMap<Pubkey, u64>,
@@ -410,7 +401,7 @@ impl EgressMessages {
 
         // let lower_bound = stakes_vec[stakes_vec.len() - 1].1; //lowest stake
         let lower_bound = 0;
-        let num_buckets = 100; // TODO: make configurable
+        let num_buckets = 20; // TODO: make configurable
         let bucket_range: u64;
 
         if upper_bound == lower_bound || lower_bound + 1 == upper_bound {
@@ -475,7 +466,7 @@ impl EgressMessages {
 
             if *stake >= self.min_entry && *stake <= self.max_entry {
                 let bucket: u64 = (*stake - self.min_entry) / self.bucket_range;
-                info!("pubkey, stake, bucket, msgs: {:?}, {}, {}, {}", pubkey, stake, bucket, egress_messages);
+                // info!("pubkey, stake, bucket, msgs: {:?}, {}, {}, {}", pubkey, stake, bucket, egress_messages);
                 // add total egress messages to bucket entry.
                 // if bucket entry doesn't exist, begin it with the current egress_messages count
                 *self.entries.entry(bucket).or_insert(0) += *egress_messages;

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -553,18 +553,19 @@ impl InfluxDataPoint {
     // We want to pass in the actual bucket values instead of the stake values
     // that way when we see bucket 1, we know that that is the lowest 1-2% of all 
     // staked nodes in the network
-    pub fn create_egress_messages_point(
+    pub fn create_messages_point(
         &mut self,
-        egress_messages: &Histogram,
+        messages_direction: String,
+        messages: &Histogram,
         simulation_iter_val: usize,
     ) {
-        for (bucket, egress_count) in egress_messages.entries().iter() {
-            let data_point  = format!("egress_message_count,simulation_iter={} bucket={},count={} ", simulation_iter_val, bucket , egress_count);
+        for (bucket, egress_count) in messages.entries().iter() {
+            let data_point  = format!("{},simulation_iter={} bucket={},count={} ", messages_direction, simulation_iter_val, bucket , egress_count);
             self.datapoint.push_str(data_point.as_str());
             self.set_and_append_timestamp();
         }
 
-        debug!("egress histogram point: {}", self.datapoint);
+        debug!("{} histogram point: {}", messages_direction, self.datapoint);
     }
 
 

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -473,8 +473,7 @@ impl InfluxDataPoint {
             self.set_and_append_timestamp();
         }
 
-        info!("validator stake dis histogram point: {}", self.datapoint);
-
+        debug!("validator stake dis histogram point: {}", self.datapoint);
     }
 
     pub fn create_config_point(

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -564,7 +564,7 @@ impl InfluxDataPoint {
             self.set_and_append_timestamp();
         }
 
-        info!("egress histogram point: {}", self.datapoint);
+        debug!("egress histogram point: {}", self.datapoint);
     }
 
 

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -7,7 +7,6 @@ use {
         HopsStat,
         StrandedNodeStats,
         Histogram,
-        EgressMessages,
     },
     crate::gossip::{
         Testing,
@@ -550,24 +549,17 @@ impl InfluxDataPoint {
         debug!("histogram point: {}", self.datapoint);
     }
 
-    // this is really a histogram. needs refactor
+    // for egress message histogram, since the x axis is percentage of stake
+    // We want to pass in the actual bucket values instead of the stake values
+    // that way when we see bucket 1, we know that that is the lowest 1-2% of all 
+    // staked nodes in the network
     pub fn create_egress_messages_point(
         &mut self,
-        egress_messages: &EgressMessages,
+        egress_messages: &Histogram,
         simulation_iter_val: usize,
     ) {
         for (bucket, egress_count) in egress_messages.entries().iter() {
-            // let bucket_min = egress_messages.min_entry() + bucket * egress_messages.bucket_range();
-            // let bucket_max = egress_messages.min_entry() + (bucket + 1) * egress_messages.bucket_range() - 1;
-            // if bucket_min == bucket_max {
-            //     debug!("Bucket: {}: Message Count: {}", bucket_max, egress_count);
-            // } else {
-            //     debug!("Bucket: {}-{}: Message Count: {}", bucket_min, bucket_max, egress_count);
-            // }
-            // let data_point  = format!("egress_message_count,simulation_iter={} bucket={},count={} ", simulation_iter_val, bucket_max / 1000000000 , egress_count);
             let data_point  = format!("egress_message_count,simulation_iter={} bucket={},count={} ", simulation_iter_val, bucket , egress_count);
-
-
             self.datapoint.push_str(data_point.as_str());
             self.set_and_append_timestamp();
         }

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -463,6 +463,20 @@ impl InfluxDataPoint {
         self.append_timestamp();
     }
 
+    pub fn create_validator_stake_distribution_histogram_point(
+        &mut self,
+        stake_distribution_histogram: &Histogram,
+    ) {
+        for (bucket, count) in stake_distribution_histogram.entries().iter() {
+            let data_point  = format!("validator_stake_distribution bucket={},count={} ", bucket , count);
+            self.datapoint.push_str(data_point.as_str());
+            self.set_and_append_timestamp();
+        }
+
+        info!("validator stake dis histogram point: {}", self.datapoint);
+
+    }
+
     pub fn create_config_point(
         &mut self,
         push_fanout: usize,
@@ -559,14 +573,12 @@ impl InfluxDataPoint {
         messages: &Histogram,
         simulation_iter_val: usize,
     ) {
-        for (bucket, egress_count) in messages.entries().iter() {
-            let data_point  = format!("{},simulation_iter={} bucket={},count={} ", messages_direction, simulation_iter_val, bucket , egress_count);
+        for (bucket, message_count) in messages.entries().iter() {
+            let data_point  = format!("{},simulation_iter={} bucket={},count={} ", messages_direction, simulation_iter_val, bucket , message_count);
             self.datapoint.push_str(data_point.as_str());
             self.set_and_append_timestamp();
         }
 
         debug!("{} histogram point: {}", messages_direction, self.datapoint);
     }
-
-
 }

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -346,6 +346,21 @@ impl InfluxDataPoint {
         self.datapoint.push_str(self.get_timestamp_now().as_str());
     }
 
+    pub fn create_rmr_data_point(
+        &mut self,
+        (rmr, total_messages, total_nodes_rx_message): (f64, u64, u64),
+    ) {
+        self.datapoint.push_str(
+            format!("rmr,simulation_iter={} rmr={},m={},n={} ", 
+                self.simulation_iteration, 
+                rmr,
+                total_messages,
+                total_nodes_rx_message
+            ).as_str()
+        );
+        self.append_timestamp();
+    }
+
     pub fn create_data_point(
         &mut self,
         data: f64,

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -7,6 +7,7 @@ use {
         HopsStat,
         StrandedNodeStats,
         Histogram,
+        EgressMessages,
     },
     crate::gossip::{
         Testing,
@@ -546,6 +547,29 @@ impl InfluxDataPoint {
         }
 
         debug!("histogram point: {}", self.datapoint);
+    }
+
+    // this is really a histogram. needs refactor
+    pub fn create_egress_messages_point(
+        &mut self,
+        egress_messages: &EgressMessages,
+        simulation_iter_val: usize,
+    ) {
+        for (bucket, egress_count) in egress_messages.entries().iter() {
+            let bucket_min = egress_messages.min_entry() + bucket * egress_messages.bucket_range();
+            let bucket_max = egress_messages.min_entry() + (bucket + 1) * egress_messages.bucket_range() - 1;
+            if bucket_min == bucket_max {
+                debug!("Bucket: {}: Message Count: {}", bucket_max, egress_count);
+            } else {
+                debug!("Bucket: {}-{}: Message Count: {}", bucket_min, bucket_max, egress_count);
+            }
+            let data_point  = format!("egress_message_count,simulation_iter={} bucket={},count={} ", simulation_iter_val, bucket_max, egress_count);
+
+            self.datapoint.push_str(data_point.as_str());
+            self.set_and_append_timestamp();
+        }
+
+        info!("egress histogram point: {}", self.datapoint);
     }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,12 @@ pub const API_TESTNET: &str = "https://api.testnet.solana.com";
 pub const INFLUX_INTERNAL_METRICS: &str = "https://internal-metrics.solana.com:8086";
 pub const INFLUX_LOCALHOST: &str = "http://localhost:8086";
 
+pub const VALIDATOR_STAKE_DISTRIBUTION_NUM_BUCKETS: u64 = 50; // for validator histogram
+pub const AGGREGATE_HOPS_FAIL_NODES_HISTOGRAM_UPPER_BOUND: f64 = 40.0;
+pub const AGGREGATE_HOPS_MIN_INGRESS_NODES_HISTOGRAM_UPPER_BOUND: u64 = 50;
+pub const STANDARD_HISTOGRAM_UPPER_BOUND: u64 = 30;
+
+
 pub mod gossip_stats;
 pub mod gossip;
 pub mod influx_db;


### PR DESCRIPTION
reports a histogram to influx that is presented on grafana. Looks something like this:
<img width="1663" alt="Screenshot 2023-06-26 at 5 38 16 PM" src="https://github.com/gregcusack/gossip-sim/assets/11299967/43fbd0df-d705-4101-9d69-d0ffd0d84e2e">

50 buckets so every bucket is 2% stake