### PR TITLE
Add Node stake distribution histogram to influx

### DIFF
--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -38,6 +38,12 @@ use {
     rand::SeedableRng,
     rayon::prelude::*,
     dotenv::dotenv,
+    gossip_sim::{
+        AGGREGATE_HOPS_FAIL_NODES_HISTOGRAM_UPPER_BOUND,
+        AGGREGATE_HOPS_MIN_INGRESS_NODES_HISTOGRAM_UPPER_BOUND,
+        STANDARD_HISTOGRAM_UPPER_BOUND,
+        VALIDATOR_STAKE_DISTRIBUTION_NUM_BUCKETS,
+    }
 };
 
 fn parse_matches() -> ArgMatches {
@@ -347,7 +353,10 @@ fn run_simulation(
     stats.set_simulation_parameters(config);
     stats.set_origin(*origin_pubkey);
     stats.initialize_message_stats(&stakes);
-    stats.build_validator_stake_distribution_histogram(100, &stakes);
+    stats.build_validator_stake_distribution_histogram(
+        VALIDATOR_STAKE_DISTRIBUTION_NUM_BUCKETS, 
+        &stakes
+    );
 
     if simulation_iteration == 0 {
         match datapoint_queue {
@@ -537,18 +546,18 @@ fn run_simulation(
         );
         if config.test_type == Testing::FailNodes {
             stats.build_aggregate_hops_stats_histogram(
-                (40.0 * (1.0 + config.fraction_to_fail)) as u64,
+                (AGGREGATE_HOPS_FAIL_NODES_HISTOGRAM_UPPER_BOUND * (1.0 + config.fraction_to_fail)) as u64,
                     0,
                     config.num_buckets_for_hops_stats_hist // 25  
             );
         } else if config.test_type == Testing::MinIngressNodes {
             stats.build_aggregate_hops_stats_histogram(
-                50,
-                    0,
-                    config.num_buckets_for_hops_stats_hist //25
+                AGGREGATE_HOPS_MIN_INGRESS_NODES_HISTOGRAM_UPPER_BOUND,
+                0,
+                config.num_buckets_for_hops_stats_hist //25
             );
         } else {
-            stats.build_aggregate_hops_stats_histogram(30, 0, config.num_buckets_for_hops_stats_hist);
+            stats.build_aggregate_hops_stats_histogram(STANDARD_HISTOGRAM_UPPER_BOUND, 0, config.num_buckets_for_hops_stats_hist);
         }
 
         stats.build_message_histograms(config.num_buckets_for_message_hist, true, &stakes);

--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -347,7 +347,7 @@ fn run_simulation(
     stats.set_simulation_parameters(config);
     stats.set_origin(*origin_pubkey);
     stats.initialize_message_stats(&stakes);
-    stats.build_validator_stake_distribution_histogram(10, &stakes);
+    stats.build_validator_stake_distribution_histogram(100, &stakes);
 
     if simulation_iteration == 0 {
         match datapoint_queue {

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -473,8 +473,7 @@ impl InfluxDataPoint {
             self.set_and_append_timestamp();
         }
 
-        info!("validator stake dis histogram point: {}", self.datapoint);
-
+        debug!("validator stake dis histogram point: {}", self.datapoint);
     }
 
     pub fn create_config_point(

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -463,6 +463,20 @@ impl InfluxDataPoint {
         self.append_timestamp();
     }
 
+    pub fn create_validator_stake_distribution_histogram_point(
+        &mut self,
+        stake_distribution_histogram: &Histogram,
+    ) {
+        for (bucket, count) in stake_distribution_histogram.entries().iter() {
+            let data_point  = format!("validator_stake_distribution bucket={},count={} ", bucket , count);
+            self.datapoint.push_str(data_point.as_str());
+            self.set_and_append_timestamp();
+        }
+
+        info!("validator stake dis histogram point: {}", self.datapoint);
+
+    }
+
     pub fn create_config_point(
         &mut self,
         push_fanout: usize,
@@ -559,14 +573,12 @@ impl InfluxDataPoint {
         messages: &Histogram,
         simulation_iter_val: usize,
     ) {
-        for (bucket, egress_count) in messages.entries().iter() {
-            let data_point  = format!("{},simulation_iter={} bucket={},count={} ", messages_direction, simulation_iter_val, bucket , egress_count);
+        for (bucket, message_count) in messages.entries().iter() {
+            let data_point  = format!("{},simulation_iter={} bucket={},count={} ", messages_direction, simulation_iter_val, bucket , message_count);
             self.datapoint.push_str(data_point.as_str());
             self.set_and_append_timestamp();
         }
 
         debug!("{} histogram point: {}", messages_direction, self.datapoint);
     }
-
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,12 @@ pub const API_TESTNET: &str = "https://api.testnet.solana.com";
 pub const INFLUX_INTERNAL_METRICS: &str = "https://internal-metrics.solana.com:8086";
 pub const INFLUX_LOCALHOST: &str = "http://localhost:8086";
 
+pub const VALIDATOR_STAKE_DISTRIBUTION_NUM_BUCKETS: u64 = 50; // for validator histogram
+pub const AGGREGATE_HOPS_FAIL_NODES_HISTOGRAM_UPPER_BOUND: f64 = 40.0;
+pub const AGGREGATE_HOPS_MIN_INGRESS_NODES_HISTOGRAM_UPPER_BOUND: u64 = 50;
+pub const STANDARD_HISTOGRAM_UPPER_BOUND: u64 = 30;
+
+
 pub mod gossip_stats;
 pub mod gossip;
 pub mod influx_db;


### PR DESCRIPTION
reports a histogram to influx that is presented on grafana. Looks something like this:
<img width="1663" alt="Screenshot 2023-06-26 at 5 38 16 PM" src="https://github.com/gregcusack/gossip-sim/assets/11299967/43fbd0df-d705-4101-9d69-d0ffd0d84e2e">

50 buckets so every bucket is 2% stake