### PR TITLE
log start time to console for easier grafana querying.

### DIFF
--- a/src/gossip_main.rs
+++ b/src/gossip_main.rs
@@ -723,6 +723,10 @@ fn main() {
 
     let start_timestamp = get_timestamp();
 
+    info!("############################################");
+    info!("##### START_TIME: {} ######", start_timestamp);
+    info!("############################################");
+
     let mut datapoint_queue: Option<Arc<Mutex<VecDeque<InfluxDataPoint>>>> = None;
     let mut influx_thread: Option<JoinHandle<()>> = None;
     let influx_type = matches
@@ -971,6 +975,9 @@ fn main() {
             warn!("WARNING: Gossip Stats Collection is empty. Is `Iterations` <= `warm-up-rounds`?");
         }
     }
+    info!("############################################");
+    info!("##### START_TIME: {} ######", start_timestamp);
+    info!("############################################");
 }
 
 #[cfg(test)]

--- a/src/influx_db.rs
+++ b/src/influx_db.rs
@@ -536,8 +536,8 @@ impl InfluxDataPoint {
                 median_iter_stranded={},\
                 mean_weighted_stake={},\
                 median_weighted_stake={} ", 
-                self.start_timestamp,
                 self.simulation_iteration,
+                self.start_timestamp,
                 total_stranded_iterations_count,
                 mean_number_of_iterations_node_stranded_for,
                 mean_number_of_nodes_stranded_during_each_iteration,


### PR DESCRIPTION
also fix bug in influx reporting. had flipped simulation_iter and start_time. 